### PR TITLE
FunctionalAcknowledgment997 Module Removed

### DIFF
--- a/jEDIMaster/nbproject/project.properties
+++ b/jEDIMaster/nbproject/project.properties
@@ -9,9 +9,5 @@ auxiliary.org-netbeans-modules-apisupport-installer.os-windows=true
 auxiliary.org-netbeans-modules-apisupport-installer.pack200-enabled=false
 auxiliary.org-netbeans-spi-editor-hints-projects.perProjectHintSettingsFile=nbproject/cfg_hints.xml
 modules=\
-    ${project.com.is2300.jedi.edi.global}:\
-    ${project.com.is2300.jedi.edi.fa997}:\
-    ${project.com.is2300.jedi.edi.fa997}:\
     ${project.com.is2300.jedi.edi.global}
-project.com.is2300.jedi.edi.fa997=../FunctionalAcknowledgment997
-project.com.is2300.jedi.edi.global=../EDIGlobal
+project.com.is2300.jedi.edi.global=../../EDIGlobal


### PR DESCRIPTION
Removed the FunctionalAcknowledgment997 Module.
Removed and re-added the EDIGlobal module.

Was having compile problems referring to a duplicate module already 
existing for FunctionalAcknowledgment997 Module, so removed the module.

Next compile gave me the same exception for the EDIGlobal Module, so 
copied the source out of the project, deleted EDIGlobal from the project
and re-added EDIGlobal.

Project now successfully compiles.

Needed to remove FunctionalAcknowledgment997 Module, anyway, because we
are going to approach EDI processing in a more generic manner than we
were attempting before.